### PR TITLE
Change all cdn.jsdelivr.net links to raw GitHub content links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ You can edit which indexes the mod downloads on startup in the mod's settings on
 
 #### Default Indexes
 These are the indexes that come with the mod by default:
-- https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/official.json.gz
-- https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/sfh-rooot.json.gz
-- https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/sfh-yt.json.gz
+- https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/official.json.gz
+- https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/sfh-rooot.json.gz
+- https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/sfh-yt.json.gz
 
 These are generated from [FlafyDev/auto-nong-indexes](https://github.com/FlafyDev/auto-nong-indexes).
 

--- a/mod.json
+++ b/mod.json
@@ -56,8 +56,8 @@
       "description": "Auto Nong indexes.\nFrom indexes the mod knows where to fetch the songs from.",
       "type": "custom",
       "default": [
-        "https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/official.json.gz",
-        "https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/sfh-rooot.json.gz"
+        "https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/official.json.gz",
+        "https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/sfh-rooot.json.gz"
       ]
     },
     "show-level-popup": {


### PR DESCRIPTION
**Note:** the following tests were performed after both services fully cached all the files, using Curl and HTTP Debugger.
<details>
  <summary>Results</summary>

### GitHub
https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/official.json.gz
1st: `0.014s`
2nd: `0.011s`
3rd: `0.011s`
**Avg:** `0.012s`

https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/sfh-yt.json.gz
1st: `0.033s`
2nd: `0.032s`
3rd: `0.031s`
**Avg:** `0.032s`

https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/sfh-rooot.json.gz
1st: `0.041s`
2nd: `0.030s`
3rd: `0.038s`
**Avg:** `0.036s`

https://raw.githubusercontent.com/FlafyDev/auto-nong-indexes/dist/sfh-pingusmc.json.gz
1st: `0.036s`
2nd: `0.045s`
3rd: `0.034s`
**Avg:** `0.038s`

**Avg for all:** `0.0295s`
----------

### cdn.jsdelivr.net
https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/official.json.gz
1st: `0.024s`
2nd: `0.021s`
3rd: `0.024s`
**Avg:** `0.023s`

https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/sfh-yt.json.gz
1st: `0.054s`
2nd: `0.047s`
3rd: `0.043s`
**Avg:** `0.048s`

https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/sfh-rooot.json.gz
1st: `0.053s`
2nd: `0.061s`
3rd: `0.058s`
**Avg:** `0.057s`

https://cdn.jsdelivr.net/gh/FlafyDev/auto-nong-indexes@dist/sfh-pingusmc.json.gz
1st: `0.058s`
2nd: `0.050s`
3rd: `0.062s`
**Avg:** `0.056s`

**Avg for all:** `0.046s`
----------

</details>

Using raw GitHub is **faster** by `0.0165s`, and should probably also solve the need to purge the CDN's cache.

Honestly this seems a bit stupid lol, and I would completely understand if this would get refused.